### PR TITLE
fix the tags url's in the model page

### DIFF
--- a/app/routes/__layout/$username.$modelId.tsx
+++ b/app/routes/__layout/$username.$modelId.tsx
@@ -257,7 +257,7 @@ export default function ModelDetailPage() {
                   return (
                     <li key={tag}>
                       <ButtonLink
-                        to={`/?tags=${tag}`}
+                        to={`/all/?tags=${tag}`}
                         prefetch="intent"
                         className="px-2 py-1 rounded-lg border border-white/20 inline-block font-satoshi-regular text-white/80"
                       >


### PR DESCRIPTION
There is redirect from `/`  to `/all`, which doesn't preserve the query parameters.
Because of it, the model tag urls should be `/all?tag=xxx` instead of `/?tag=xxx`.